### PR TITLE
Consider that not all the columns start at the same top position

### DIFF
--- a/src/bricklayer.ts
+++ b/src/bricklayer.ts
@@ -128,7 +128,7 @@ module Bricklayer {
 
     private findMinHeightColumn() {
       var allColumns = toArray(this.getColumns())
-      let heights = allColumns.map(column => column.offsetHeight)
+      let heights = allColumns.map(column => column.offsetHeight + column.offsetTop)
       let minHeight = Math.min.apply(null, heights)
       return allColumns[heights.indexOf(minHeight)]
     }


### PR DESCRIPTION
Review the `findMinHeightColumn()` function to take the `offsetTop` column property into account